### PR TITLE
Refactor server shutdown logic and update tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work
 bin/
 
 certs/
+
+coverage.txt

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"log"
 	"net/http"
 	"os/signal"
@@ -47,8 +46,7 @@ func main() {
 
 	log.Println("starting server...")
 
-	err := srv.ListenAndServeWithShutdown(ctx)
-	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+	if err := srv.ListenAndServeWithShutdown(ctx); err != nil {
 		log.Fatal(err)
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type delayedHandler struct {
@@ -94,7 +95,7 @@ func TestGracefulServer_ListenAndServeWithShutdown(t *testing.T) {
 		_, err := http.Get("http://" + host)
 		require.Error(t, err)
 
-		require.ErrorIs(t, <-done, context.DeadlineExceeded)
+		require.NoError(t, <-done)
 	})
 }
 
@@ -210,7 +211,7 @@ func TestGracefulServer_ListenAndServeTLSWithShutdown(t *testing.T) {
 		_, err = client.Do(r)
 		require.Error(t, err)
 
-		require.ErrorIs(t, <-done, context.DeadlineExceeded)
+		require.NoError(t, <-done)
 	})
 }
 


### PR DESCRIPTION
Revised the shutdown mechanism in the GracefulServer by consolidating `listenAndServe` and `listenAndServeTLS` methods into one with a closure strategy. Updated server tests to expect no errors instead of context deadline exceeded. Added `coverage.txt` to `.gitignore` for better test coverage management.